### PR TITLE
fix: garbleText compatibility not future-proof

### DIFF
--- a/src/fountain-view.ts
+++ b/src/fountain-view.ts
@@ -14,7 +14,7 @@ import { ftn } from "./lang-fountain";
 const theme = EditorView.theme({
 	".cm-line": {
 		caretColor: "var(--text-normal)",
-		"fontFamily": "'Courier Final Draft', 'Courier Screenplay', 'Courier Prime' !important"
+		"fontFamily": "'Courier Final Draft', 'Courier Screenplay', 'Courier Prime'"
 	},
 
 	".cm-foldGutter": {

--- a/src/styles.css
+++ b/src/styles.css
@@ -22,13 +22,7 @@
 [data-type="fountain"] .cm-line,
 [data-type="fountain"] .view-content .cm-editor {
 	font-size: 12pt;
-	font-family: 'Courier Final Draft', 'Courier Screenplay', 'Courier Prime' !important;
-}
-.is-text-garbled [data-type="fountain"] .cm-scroller,
-.is-text-garbled [data-type="fountain"] *.cm-line,
-.is-text-garbled [data-type="fountain"] .view-content .cm-editor {
-	font-family: 'Flow Circular', sans-serif !important;
-	line-height: 1.45em !important;
+	font-family: 'Courier Final Draft', 'Courier Screenplay', 'Courier Prime';
 }
 [data-type="fountain"] .view-content .cm-editor::selection, 
 [data-type="fountain"] .cm-line::selection {


### PR DESCRIPTION
## Overview

Fix garbleText compatibility by removing `!important`.

<details><summary>Why is this solution preferable to 3af4e3f?</summary>

**The new solution is independent of the third-party plugin the old solution relies on.** The 3af4e3f solution relies on a class name (`.is-text-garbled`) specific to a third-party plugin (https://github.com/kurakart/garble-text). That is a problem because the plugin may be [discontinued](https://github.com/kurakart/garble-text/commit/35ac912) **or** change its class name, and then the code suddenly becomes outdated **or** incorrect.

</details>

<details><summary>Will removing <code>!important</code> cause other problems?</summary>

**I doubt it.** The `!important` fixes the problem. The removal of it was otherwise inconsequential for me. Notice, [Obsidian suggests not using `!important`](https://docs.obsidian.md/Themes/App+themes/Theme+guidelines#Avoid+%60!important%60+declarations). Also, [the use of `!important` may have been a desperate patch](https://cssguidelin.es/#important).

</details>

## Changes

- **removed** `!important` from `font-family` rules
- **removed** `.is-text-garbled` styles

## Testing

<details><summary>Install "Garble Text" plugin and this plugin, then test that "Garble Text" command works.</summary>

1. Install this plugin with this change, e.g.
	- Install this plugin on this branch.
	- Install the original plugin, and use DevTools to mimic the changes in this PR.
2. Install https://github.com/kurakart/garble-text.
3. Run command "Garble Text: Toggle Garble Text".
3. Verify text is garbled.
4. Close document.
5. Open document.
6. Verify text is garbled.
7. Run command "Garble Text: Toggle Garble Text".
8. Verify text is not garbled.
9. Run command "Garble Text: Toggle Garble Text".
10. Verify text is garbled.

</details>

## UI

https://github.com/GamerGirlandCo/obsidian-fountain-revived/assets/62723358/2ee96dc0-b7e5-4abc-b2d4-15ef5d887e24