### PR TITLE
fix: missing fallback fonts

### DIFF
--- a/src/fountain-view.ts
+++ b/src/fountain-view.ts
@@ -14,7 +14,7 @@ import { ftn } from "./lang-fountain";
 const theme = EditorView.theme({
 	".cm-line": {
 		caretColor: "var(--text-normal)",
-		"fontFamily": "'Courier Final Draft', 'Courier Screenplay', 'Courier Prime' !important"
+		"fontFamily": "'Courier Final Draft', 'Courier Screenplay', 'Courier Prime', Courier, monospace !important"
 	},
 
 	".cm-foldGutter": {

--- a/src/styles.css
+++ b/src/styles.css
@@ -22,7 +22,7 @@
 [data-type="fountain"] .cm-line,
 [data-type="fountain"] .view-content .cm-editor {
 	font-size: 12pt;
-	font-family: 'Courier Final Draft', 'Courier Screenplay', 'Courier Prime' !important;
+	font-family: 'Courier Final Draft', 'Courier Screenplay', 'Courier Prime', 'Courier', monospace !important;
 }
 .is-text-garbled [data-type="fountain"] .cm-scroller,
 .is-text-garbled [data-type="fountain"] *.cm-line,


### PR DESCRIPTION
## Overview

Add fonts that are available to all users.

<details>

Not all users have `'Courier Final Draft', 'Courier Screenplay', 'Courier Prime'`. Without those fonts, the user can still have a monospace font.

</details>

## Testing

Load on system without preferred Courier fonts, then verify that fountain document is monospace.

## UI

Before, font is serif (browser default). After, font is monospace (from new code).

| before | after |
| - | - |
| ![before - css](https://github.com/wesleyboar/obsidian-fountain-revived/assets/62723358/3629ffa1-7995-4375-be2e-eafddd10b033) | ![after - css](https://github.com/wesleyboar/obsidian-fountain-revived/assets/62723358/e1f4700e-273e-4e87-a900-f4b872a938fe) |
| ![before - font](https://github.com/wesleyboar/obsidian-fountain-revived/assets/62723358/610cf98b-50f3-449f-8e8f-708b0ae3323c) | ![after - font](https://github.com/wesleyboar/obsidian-fountain-revived/assets/62723358/59ff38a2-d04a-416f-97ce-c372eaecf151) |

## Notes

This feature was removed (perhaps by accident) in 3af4e3f. I also added the [generic name](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#generic-name) `monospace`, because it is good practice to do so.