### PR TITLE
fix: redundant font family

### DIFF
--- a/src/fountain-view.ts
+++ b/src/fountain-view.ts
@@ -13,8 +13,7 @@ import { ftn } from "./lang-fountain";
 
 const theme = EditorView.theme({
 	".cm-line": {
-		caretColor: "var(--text-normal)",
-		"fontFamily": "'Courier Final Draft', 'Courier Screenplay', 'Courier Prime' !important"
+		caretColor: "var(--text-normal)"
 	},
 
 	".cm-foldGutter": {

--- a/src/styles.css
+++ b/src/styles.css
@@ -22,7 +22,7 @@
 [data-type="fountain"] .cm-line,
 [data-type="fountain"] .view-content .cm-editor {
 	font-size: 12pt;
-	font-family: 'Courier Final Draft', 'Courier Screenplay', 'Courier Prime' !important;
+	font-family: 'Courier Final Draft', 'Courier Screenplay', 'Courier Prime';
 }
 .is-text-garbled [data-type="fountain"] .cm-scroller,
 .is-text-garbled [data-type="fountain"] *.cm-line,

--- a/src/styles.css
+++ b/src/styles.css
@@ -22,7 +22,7 @@
 [data-type="fountain"] .cm-line,
 [data-type="fountain"] .view-content .cm-editor {
 	font-size: 12pt;
-	font-family: 'Courier Final Draft', 'Courier Screenplay', 'Courier Prime';
+	font-family: 'Courier Final Draft', 'Courier Screenplay', 'Courier Prime' !important;
 }
 .is-text-garbled [data-type="fountain"] .cm-scroller,
 .is-text-garbled [data-type="fountain"] *.cm-line,


### PR DESCRIPTION
## Overview

No need to apply the same font-family twice.

## Changes

- **removed** superfluous `font-family` declaration

## Testing

Use DevTools to verify the font stack only appears once.

## UI

| before | after |
| - | - |
| ![before](https://github.com/GamerGirlandCo/obsidian-fountain-revived/assets/62723358/b74751cc-feb5-4132-b051-f6ef173a7ec5) | ![after](https://github.com/GamerGirlandCo/obsidian-fountain-revived/assets/62723358/5d746599-9261-4b94-9840-206a4ad307c0) |